### PR TITLE
use papaya

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,13 +158,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -352,6 +358,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "papaya"
+version = "0.2.3"
+dependencies = [
+ "equivalent",
+ "seize",
+]
+
+[[package]]
 name = "paracord"
 version = "0.1.0-rc.7"
 dependencies = [
@@ -359,8 +373,10 @@ dependencies = [
  "clashmap",
  "foldhash",
  "hashbrown 0.15.2",
+ "papaya",
  "rand",
  "rand_distr",
+ "seize",
  "serde",
  "serde_test",
  "sync_wrapper",
@@ -567,7 +583,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -587,6 +603,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b8d813387d566f627f3ea1b914c068aac94c40ae27ec43f5f33bde65abefe7"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "serde"
@@ -656,7 +682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -846,6 +872,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
  "windows-targets",
 ]
 

--- a/paracord/Cargo.toml
+++ b/paracord/Cargo.toml
@@ -20,6 +20,8 @@ clashmap = { version = "1.2", features = ["raw-api"] }
 typed-arena = "2"
 hashbrown = { version = "0.15", default-features = false }
 sync_wrapper = "1"
+papaya = { path = "../../papaya" }
+seize = "0.5"
 
 serde = { version = "1", optional = true }
 

--- a/paracord/src/lib.rs
+++ b/paracord/src/lib.rs
@@ -472,6 +472,28 @@ impl<S> Index<Key> for ParaCord<S> {
     }
 }
 
+#[repr(transparent)]
+struct AsBytes<S: AsRef<str>>(S);
+impl<S: AsRef<str>> AsRef<[u8]> for AsBytes<S> {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref().as_bytes()
+    }
+}
+
+impl<I: AsRef<str>, S: BuildHasher + Default> FromIterator<I> for crate::ParaCord<S> {
+    fn from_iter<A: IntoIterator<Item = I>>(iter: A) -> Self {
+        Self {
+            inner: iter.into_iter().map(AsBytes).collect(),
+        }
+    }
+}
+
+impl<I: AsRef<str>, S: BuildHasher> Extend<I> for crate::ParaCord<S> {
+    fn extend<A: IntoIterator<Item = I>>(&mut self, iter: A) {
+        self.inner.extend(iter.into_iter().map(AsBytes));
+    }
+}
+
 mod iter_private {
     use crate::Key;
 

--- a/paracord/src/lib.rs
+++ b/paracord/src/lib.rs
@@ -124,9 +124,15 @@ custom_key!(
 ///
 /// [`Key`] implements [`core::cmp::Ord`] for use within collections like [`BTreeMap`](std::collections::BTreeMap),
 /// but the order is not defined to be meaningful or relied upon. Treat [`Key`]s as opaque blobs, with an unstable representation.
-#[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Copy)]
 #[repr(transparent)]
 pub struct Key(NonZeroU32);
+
+impl std::fmt::Debug for Key {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Key").field(&self.into_repr()).finish()
+    }
+}
 
 impl Key {
     /// Turn the key into a u32.
@@ -550,7 +556,7 @@ mod tests {
             for _ in 0..THREADS {
                 s.spawn(|| {
                     barrier.wait();
-                    
+
                     let a = paracord.get_or_intern("A");
                     assert_eq!(a, paracord.get_or_intern("A"));
 
@@ -811,6 +817,6 @@ mod tests {
 
         // average 86 bytes per string.
         // average string length is 24, so 62 bytes overhead.
-        assert_eq!(mem / len, 86);
+        assert_eq!(mem / len, 50);
     }
 }

--- a/paracord/src/lib.rs
+++ b/paracord/src/lib.rs
@@ -815,8 +815,8 @@ mod tests {
         let mem = interner.current_memory_usage();
         let len = interner.len();
 
-        // average 86 bytes per string.
-        // average string length is 24, so 62 bytes overhead.
-        assert_eq!(mem / len, 50);
+        // average 70 bytes per string.
+        // average string length is 24, so 46 bytes overhead.
+        assert_eq!(mem / len, 70);
     }
 }

--- a/paracord/src/slice/lock_free.rs
+++ b/paracord/src/slice/lock_free.rs
@@ -1,0 +1,79 @@
+//! Lock-free portion of paracord.
+
+use std::hash::{BuildHasher, Hash};
+
+use papaya::table::{HashTable, InsertResult, VerifiedGuard};
+use seize::Collector;
+
+use crate::slice::InternedPtr;
+use crate::Key;
+
+fn table<T>(cap: usize) -> HashTable<InternedPtr<T>, NoDealloc> {
+    HashTable::new(cap, Collector::default(), papaya::ResizeMode::default())
+}
+
+pub(super) struct NoDealloc;
+impl<T> papaya::table::Dealloc<T> for NoDealloc {
+    #[inline(always)]
+    unsafe fn dealloc(_: *mut T) {}
+}
+
+pub(super) struct LockFreeParacord<T, S = foldhash::fast::RandomState> {
+    // stores pointers to keys_to_slice, so must be dropped first
+    pub(super) slice_to_keys: HashTable<InternedPtr<T>, NoDealloc>,
+    pub(super) keys_to_slice: boxcar::Vec<InternedPtr<T>>,
+    pub(super) hasher: S,
+}
+
+impl<T, S> LockFreeParacord<T, S> {
+    pub(super) fn with_capacity_and_hasher(cap: usize, hasher: S) -> Self {
+        Self {
+            slice_to_keys: table(cap),
+            keys_to_slice: boxcar::Vec::with_capacity(cap),
+            hasher,
+        }
+    }
+
+    pub(super) fn clear(&mut self) {
+        // must clear slice_to_keys first
+        self.slice_to_keys = table(self.slice_to_keys.len());
+        self.keys_to_slice.clear();
+    }
+}
+
+impl<T: Hash + Eq, S: BuildHasher> LockFreeParacord<T, S> {
+    pub(super) fn find(&self, s: &[T], hash: u64, guard: &impl VerifiedGuard) -> Option<Key> {
+        // safety: k is allocated correct
+        let eq = |k: *mut InternedPtr<T>| unsafe { s == (*k).slice() };
+        // safety: k is allocated correct
+        let map = |k: *mut InternedPtr<T>| unsafe { (*k).key };
+
+        self.slice_to_keys.find(hash, eq, guard).map(map)
+    }
+
+    pub(super) fn insert(&self, s: &mut [T], hash: u64, guard: &impl VerifiedGuard) -> Key {
+        let key = self.keys_to_slice.push_with(|key| {
+            let key = Key::from_index(key);
+            InternedPtr::new(s, key)
+        });
+
+        // safety: we have just inserted this entry
+        let entry = unsafe { self.keys_to_slice.get_unchecked(key) };
+
+        // safety: k is allocated correct
+        let eq = |k: *mut InternedPtr<T>| unsafe { s == (*k).slice() };
+        // safety: k is allocated correct
+        let hasher = |k: *mut InternedPtr<T>| unsafe { self.hasher.hash_one((*k).slice()) };
+
+        let k = (entry as *const InternedPtr<T>).cast_mut();
+        let res = self.slice_to_keys.insert(hash, k, eq, hasher, false, guard);
+
+        match res {
+            InsertResult::Inserted => Key::from_index(key),
+            InsertResult::Replaced(_) => unreachable!("we do not replace"),
+            InsertResult::Error(_) => unreachable!(
+                "while holding the lock, we checked for this entry already and it was not in there"
+            ),
+        }
+    }
+}


### PR DESCRIPTION
Blocked on https://github.com/ibraheemdev/papaya/pull/78

Papaya allows us to get lock-free lookups. This gives the following perf improvements:

old:
```
Timer precision: 41 ns
scoped               fastest       │ slowest       │ median        │ mean
╰─ paracord                        │               │               │
   ├─ get                          │               │               │
   │  ├─ t=1         13.53 ns      │ 33.15 ns      │ 15.32 ns      │ 15.31 ns
   │  ├─ t=2         19.9 ns       │ 30.45 ns      │ 24.61 ns      │ 24.78 ns
   │  ╰─ t=16        25.78 ns      │ 162.3 ns      │ 119 ns        │ 117.7 ns
   ├─ get_or_intern                │               │               │
   │  ├─ t=1         22.28 ns      │ 39.78 ns      │ 25.86 ns      │ 25.73 ns
   │  ├─ t=2         89.65 ns      │ 140.6 ns      │ 117.2 ns      │ 117.3 ns
   │  ╰─ t=16        1.155 µs      │ 2.843 µs      │ 1.709 µs      │ 1.753 µs
   ╰─ resolve                      │               │               │
      ├─ t=1         1.867 ns      │ 7.367 ns      │ 2.451 ns      │ 2.883 ns
      ├─ t=2         2.576 ns      │ 14.99 ns      │ 3.867 ns      │ 4.254 ns
      ╰─ t=16        3.367 ns      │ 38.74 ns      │ 4.409 ns      │ 5.175 ns
```

new:
```
Timer precision: 41 ns
scoped               fastest       │ slowest       │ median        │ mean
╰─ paracord                        │               │               │
   ├─ get                          │               │               │
   │  ├─ t=1         25.61 ns      │ 54.19 ns      │ 28.71 ns      │ 28.94 ns
   │  ├─ t=2         26.73 ns      │ 49.98 ns      │ 32.65 ns      │ 32.88 ns
   │  ╰─ t=16        35.78 ns      │ 124.6 ns      │ 40.21 ns      │ 47.91 ns
   ├─ get_or_intern                │               │               │
   │  ├─ t=1         35.61 ns      │ 67.86 ns      │ 43.15 ns      │ 43.49 ns
   │  ├─ t=2         149.8 ns      │ 213.4 ns      │ 173.5 ns      │ 173.9 ns
   │  ╰─ t=16        1.092 µs      │ 3.009 µs      │ 1.775 µs      │ 1.867 µs
   ╰─ resolve                      │               │               │
      ├─ t=1         2.488 ns      │ 11.69 ns      │ 3.613 ns      │ 3.884 ns
      ├─ t=2         3.072 ns      │ 9.239 ns      │ 4.821 ns      │ 5.064 ns
      ╰─ t=16        4.28 ns       │ 38.98 ns      │ 5.363 ns      │ 6.67 ns
```

There's a slight regression in the low-contention benchmarks. But in high contention, `get` is much faster on average due to not needing a read lock.

The get_or_intern case is largely unaffected, since we still use a sharded locking arena allocator.